### PR TITLE
network errors handling

### DIFF
--- a/lib/beyag/client.rb
+++ b/lib/beyag/client.rb
@@ -14,20 +14,20 @@ module Beyag
     end
 
     def query(order_id)
-      build_response get("/payments/#{order_id}")
+      get("/payments/#{order_id}")
     end
 
     def erip_payment(params)
-      build_response post('/payments', request: params)
+      post('/payments', request: params)
     end
 
     def bank_list(gateway_id)
-      build_response get("/gateways/#{gateway_id}/bank_list")
+      get("/gateways/#{gateway_id}/bank_list")
     end
 
     %i[payment refund payout].each do |method|
       define_method(method) do |params|
-        build_response post("/transactions/#{method}", request: params)
+        post("/transactions/#{method}", request: params)
       end
     end
 
@@ -40,7 +40,7 @@ module Beyag
 
     def request
       begin
-        yield
+        Response.new(yield)
       rescue Exception => e
         logger = Logger.new(STDOUT)
         logger.error("Error: #{e.message}\nTrace:\n#{e.backtrace.join("\n")}")

--- a/lib/beyag/client.rb
+++ b/lib/beyag/client.rb
@@ -62,10 +62,6 @@ module Beyag
       end
     end
 
-    def build_response(response)
-      Response.new(response)
-    end
-
     def post(path, data = {})
       request { connection.post(full_path(path), data.to_json) }
     end

--- a/lib/beyag/client.rb
+++ b/lib/beyag/client.rb
@@ -44,7 +44,7 @@ module Beyag
       rescue Exception => e
         logger = Logger.new(STDOUT)
         logger.error("Error: #{e.message}\nTrace:\n#{e.backtrace.join("\n")}")
-        OpenStruct.new(status: 422)
+        Response::Error.new(e)
       end
     end
 

--- a/lib/beyag/response.rb
+++ b/lib/beyag/response.rb
@@ -1,5 +1,31 @@
 module Beyag
   class Response
+    class Error
+      def initialize(error)
+        @error = error
+      end
+
+      def successful?
+        false
+      end
+
+      def message
+        @error.message
+      end
+
+      def errors
+        { 'error' => message }
+      end
+
+      def data
+        { 'status' => 'error', 'message' => message, 'errors' => errors }
+      end
+
+      %i[id service_no transaction payment_method status].each do |name|
+        define_method(name) {}
+      end
+    end
+
     attr_reader :response, :data
 
     def initialize(response)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -403,5 +403,19 @@ RSpec.describe Beyag::Client do
         expect(client.send(:connection).headers).to include(headers)
       end
     end
+
+    context 'when there are network issues' do
+      let(:client) { Beyag::Client.new(shop_id: '1', secret_key: '1', gateway_url: 'http://example.com') }
+
+      before do
+        stub_request(:get, /example.com\/payment/).and_raise(Net::ReadTimeout)
+      end
+
+      it 'returns error response' do
+        expect {
+          expect(client.query('')).to be_kind_of(Beyag::Response::Error)
+        }.not_to raise_exception
+      end
+    end
   end
 end


### PR DESCRIPTION
The existing `Response` type isn't fully suitable for the representation of exceptions that happen during network communication.
So we introduce new response type for this purpose.