### PR TITLE
Fix Sidekiq::Shutdown error rescuing

### DIFF
--- a/lib/beyag/client.rb
+++ b/lib/beyag/client.rb
@@ -42,7 +42,7 @@ module Beyag
     def request
       begin
         Response.new(yield)
-      rescue Exception => e
+      rescue StandardError => e
         logger.error("Error: #{e.message}\nTrace:\n#{e.backtrace.join("\n")}")
         Response::Error.new(e)
       end


### PR DESCRIPTION
Sidekiq raises Sidekiq::Shutdown error inherited from SignalException, Exception. We could catch it by rescue Exeption and prevent correct sidekiq work.